### PR TITLE
Adding 403 forbidden for expired JWTs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,4 +74,5 @@ group :test do
   gem "capybara"
   gem "selenium-webdriver"
   gem "webdrivers"
+  gem 'mocha'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,6 +125,8 @@ GEM
     mini_mime (1.1.2)
     mini_portile2 (2.8.2)
     minitest (5.18.1)
+    mocha (2.0.4)
+      ruby2_keywords (>= 0.0.5)
     msgpack (1.7.0)
     multi_xml (0.6.0)
     net-imap (0.3.6)
@@ -256,6 +258,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   jwt
+  mocha
   omniauth
   omniauth-google-oauth2
   pg (~> 1.5)

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -8,12 +8,16 @@ module Api
 
       def authenticate_user!
         token = request.headers['Authorization']&.split(' ')&.last
-        if token
-          decoded_token = JWT.decode(token, ENV["JWT_SECRET"], true, { algorithm: 'HS256' })[0]
-          @current_user = User.find(decoded_token['user_id'])
-        end
+        begin
+          if token
+            decoded_token = JWT.decode(token, ENV["JWT_SECRET"], true, { algorithm: 'HS256' })[0]
+            @current_user = User.find(decoded_token['user_id'])
+          end
 
-        head :unauthorized unless @current_user
+          head :unauthorized unless @current_user
+        rescue JWT::ExpiredSignature
+          head :forbidden
+        end
       end
     end
   end


### PR DESCRIPTION
This PR updates the base controller for the API resources to return a 403 forbidden error for expired JWT tokens, instead of a 500 response.